### PR TITLE
Hopefully mitigates maxListeners memory leak error.

### DIFF
--- a/red/openProtocol.js
+++ b/red/openProtocol.js
@@ -17,6 +17,13 @@ module.exports = function(RED) {
   // <Begin> --- Config ---
   function OpenProtocolConfig(values) {
     EventEmitter.call(this);
+    /**
+     *
+      Default listener count is 10, but if more is requested in the config, a memory leak error is thrown
+      60 is needed per Desoutter controller
+     *
+    **/
+    EventEmitter.defaultMaxListeners = 60;
     RED.nodes.createNode(this, values);
 
     const node = this;


### PR DESCRIPTION
This error is apparently thrown by the Node that is emitting the event (assuming op-config [Desoutter fork] in this case). I did not want the number of listeners to be unlimited in the case that the listeners are not cleaned after handling an event.

`(node:27) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 disconnect listeners added to [OpenProtocolConfig]. Use emitter.setMaxListeners() to increase limit`

It is believed that we require 60 as of this moment in time: 3 per controller port (tool), totaling 20 tools altogether per controller. Will need to update this value in the future based on the number of procured controllers.